### PR TITLE
Fixing usage of isOneOfRoles in read operations

### DIFF
--- a/rules/solution-rbac/step5.rules
+++ b/rules/solution-rbac/step5.rules
@@ -32,7 +32,7 @@ service cloud.firestore {
         allow delete: if isOneOfRoles(resource, ['owner']);
         allow update: if isOneOfRoles(resource, ['owner'])
                       || (isOneOfRoles(resource, ['writer']) && onlyContentChanged());
-        allow read: if isOneOfRoles(['owner', 'writer', 'commenter', 'reader']);
+        allow read: if isOneOfRoles(resource, ['owner', 'writer', 'commenter', 'reader']);
 
         match /comments/{comment} {
           allow read: if isOneOfRoles(get(/databases/$(database)/documents/stories/$(story)),


### PR DESCRIPTION
The "isOneOfRoles" function requires two parameters to work properly. This parameter was added to the  "allow read:" comparison at stories/{story} level

![data-structure](https://user-images.githubusercontent.com/3228217/63719762-4b9c9e80-c813-11e9-9708-35373bce85df.png)

![simulation-error](https://user-images.githubusercontent.com/3228217/63719751-450e2700-c813-11e9-9bb7-e95050f0b477.png)

![simulation-read-allowed](https://user-images.githubusercontent.com/3228217/63719759-48a1ae00-c813-11e9-98ec-6cf9cf7984af.png)