### PR TITLE
use encoding option when read rule settings file

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -55,7 +55,7 @@ const rbacData = new Map([
 ]);
 
 function readRulesFile(name: string): string {
-  return fs.readFileSync(getRulesFilePath(name)).toString();
+  return fs.readFileSync(getRulesFilePath(name), 'utf8');
 }
 
 function getRulesFilePath(name: string): string {


### PR DESCRIPTION
It’s a trivial matter, but I believe set encoding option is better than use '.toString()'.

It's also used in the following documents.

https://firebase.google.com/docs/firestore/security/test-rules-emulator#run_local_tests

```js
fs.readFileSync("/path/to/firestore.rules", "utf8");
```